### PR TITLE
Change default value of use rule in Sigma analyzer

### DIFF
--- a/timesketch/lib/analyzers/sigma_tagger.py
+++ b/timesketch/lib/analyzers/sigma_tagger.py
@@ -33,7 +33,7 @@ class SigmaPlugin(interface.BaseAnalyzer):
         super().__init__(index_name, sketch_id, timeline_id=timeline_id)
 
     def run_sigma_rule(
-        self, query, rule_name, tag_list=None, status_good=True):
+        self, query, rule_name, tag_list=None, status_good=False):
         """Runs a sigma rule and applies the appropriate tags.
 
         Args:


### PR DESCRIPTION
At the moment if a file is not found in the status file, the rule would be considered "good" but that might lead to a lot of problems, so changing it to False.